### PR TITLE
Prepared project for build automation. Updated Cryptography.Xml nuget.

### DIFF
--- a/Cpix.sln
+++ b/Cpix.sln
@@ -14,9 +14,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Settings", "Settings", "{34
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadmeQuickStartExamples", "ReadmeQuickStartExamples\ReadmeQuickStartExamples.csproj", "{EBBAF2D8-F96F-4744-A5A3-E4FADF06855E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReadmeQuickStartExamples", "ReadmeQuickStartExamples\ReadmeQuickStartExamples.csproj", "{EBBAF2D8-F96F-4744-A5A3-E4FADF06855E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestVectorGenerator", "TestVectorGenerator\TestVectorGenerator.csproj", "{727197E7-8742-40ED-B8D1-96659BFD7C65}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestVectorGenerator", "TestVectorGenerator\TestVectorGenerator.csproj", "{727197E7-8742-40ED-B8D1-96659BFD7C65}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Cpix/AssemblyInfo.cs
+++ b/Cpix/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Axinom.Cpix.Tests")]
-[assembly: InternalsVisibleTo("Axinom.Cpix.TestVectorGenerator")]

--- a/Cpix/Cpix.csproj
+++ b/Cpix/Cpix.csproj
@@ -1,18 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Axinom.Cpix</AssemblyName>
-    <Company>Axinom</Company>
-    <Authors>Axinom</Authors>
-    <Product>Axinom CPIX Library</Product>
-    <Copyright></Copyright>
-    <Description>Library for processing CPIX documents.</Description>
-    <PackageProjectUrl>https://github.com/Axinom/cpix</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Axinom/cpix/master/License.txt</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/Axinom/cpix/master/NuGetLogo.png</PackageIconUrl>
     <RootNamespace>Axinom.Cpix</RootNamespace>
-    <Version>2.0.0</Version>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -32,8 +24,12 @@
     <EmbeddedResource Include="..\Resources\Schema\xmldsig-core-schema.xsd" Link="xmldsig-core-schema.xsd" />
   </ItemGroup>
 
+    <ItemGroup>
+         <Compile Include="..\Resources\SolutionAssemblyInfo.cs" Link="SolutionAssemblyInfo.cs" />
+    </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.4.2" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/Resources/Nuspec/Cpix.nuspec
+++ b/Resources/Nuspec/Cpix.nuspec
@@ -2,14 +2,17 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata minClientVersion="2.8">
 		<id>Axinom.Cpix</id>
-		<version>2.0.0</version>
 		<authors>Axinom</authors>
 		<description>Library for processing CPIX documents.</description>
 		<projectUrl>https://github.com/Axinom/cpix</projectUrl>
 		<licenseUrl>https://raw.githubusercontent.com/Axinom/cpix/master/License.txt</licenseUrl>
 		<iconUrl>https://raw.githubusercontent.com/Axinom/cpix/master/NuGetLogo.png</iconUrl>
+
+		<!-- Automatically set by release automation. -->
+		<version>__NUGETPACKAGEVERSION__</version>
+
 		<dependencies>
-			<dependency id="System.Security.Cryptography.Xml" version="4.4.2" />
+			<dependency id="System.Security.Cryptography.Xml" version="4.5.0" />
 		</dependencies>
 	</metadata>
 	<files>

--- a/Resources/Resources.csproj
+++ b/Resources/Resources.csproj
@@ -1,13 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.0</Version>
-    <Authors>Axinom</Authors>
-    <Company>Axinom</Company>
-    <Product></Product>
     <AssemblyName>Axinom.Cpix.Resources</AssemblyName>
     <RootNamespace>Axinom.Cpix.Resources</RootNamespace>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
 </Project>

--- a/Resources/SolutionAssemblyInfo.cs
+++ b/Resources/SolutionAssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// This is the real version number, used in NuGet packages and for display purposes.
+[assembly: AssemblyFileVersion("2.0.0")]
+
+// Only use major version here, with others kept at zero, for correct assembly binding logic.
+[assembly: AssemblyVersion("2.0.0")]
+
+[assembly: InternalsVisibleTo("Axinom.Cpix.Tests")]
+[assembly: InternalsVisibleTo("Axinom.Cpix.TestVectorGenerator")]


### PR DESCRIPTION
- Previous version of System.Security.Cryptography nuget (v.4.2.2) stopped working when .NET Core SDK was updated from 2.1.200 to 2.1.201. Today new v4.5.0 version was released, which again works (on both SDK versions).