### PR TITLE
Better CPIX 2.2 support + other fixes/enhancements

### DIFF
--- a/Cpix/Constants.cs
+++ b/Cpix/Constants.cs
@@ -38,7 +38,7 @@ namespace Axinom.Cpix
 		/// <summary>
 		/// The correct order of the entity collection container elements in CPIX XML structure.
 		/// The schema specifies an ordered sequence and we need to ensure that we always generate
-		/// the elements in the correct XML document order, regardless of their oder in time.
+		/// the elements in the correct XML document order, regardless of their order in time.
 		/// 
 		/// Inside the top-level elements, things are simple and life is easy. All we care about is the top layer.
 		/// 

--- a/Cpix/Constants.cs
+++ b/Cpix/Constants.cs
@@ -44,12 +44,12 @@ namespace Axinom.Cpix
 		/// 
 		/// Values are name-namespace pairs.
 		/// </summary>
-		public static readonly Tuple<string, string>[] TopLevelXmlElementOrder = new Tuple<string, string>[]
+		public static readonly Tuple<string, string>[] TopLevelXmlElementOrder =
 		{
 			new Tuple<string, string>(RecipientCollection.ContainerXmlElementName, CpixNamespace),
 			new Tuple<string, string>(ContentKeyCollection.ContainerXmlElementName, CpixNamespace),
 			new Tuple<string, string>(DrmSystemCollection.ContainerXmlElementName, CpixNamespace),
-			new Tuple<string, string>("ContentKeyPeriodList", CpixNamespace),
+			new Tuple<string, string>(ContentKeyPeriodCollection.ContainerXmlElementName, CpixNamespace),
 			new Tuple<string, string>(UsageRuleCollection.ContainerXmlElementName, CpixNamespace),
 			new Tuple<string, string>("UpdateHistoryItemList", CpixNamespace),
 			new Tuple<string, string>("Signature", XmlDigitalSignatureNamespace),

--- a/Cpix/ContentKeyPeriod.cs
+++ b/Cpix/ContentKeyPeriod.cs
@@ -22,14 +22,14 @@ namespace Axinom.Cpix
 		/// for the period. Mutually inclusive with end, and mutually exclusive with
 		/// index.
 		/// </summary>
-		public DateTime? Start { get; set; }
+		public DateTimeOffset? Start { get; set; }
 
 		/// <summary>
 		/// Gets or sets the wall clock (Live) or media time (VOD) for the end time
 		/// for the period. Mutually inclusive with start, and mutually exclusive
 		/// with index.
 		/// </summary>
-		public DateTime? End { get; set; }
+		public DateTimeOffset? End { get; set; }
 
 		internal override void ValidateNewEntity(CpixDocument document)
 		{
@@ -43,11 +43,12 @@ namespace Axinom.Cpix
 
 		private void ValidateEntity()
 		{
-			if ((Index == null && (Start == null || End == null))
-				|| (Index != null && (Start != null || End != null)))
-			{
-				throw new InvalidCpixDataException("For each content key period either the index or both the start and end time must be specified.");
-			}
+			var invalidIndexStartEndCombination =
+				(Index == null && (Start == null || End == null)) ||
+				(Index != null && (Start != null || End != null));
+
+			if (invalidIndexStartEndCombination)
+				throw new InvalidCpixDataException("A content key period must specify either only the index or both the start and end time.");
 		}
 	}
 }

--- a/Cpix/ContentKeyPeriod.cs
+++ b/Cpix/ContentKeyPeriod.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+namespace Axinom.Cpix
+{
+	public sealed class ContentKeyPeriod : Entity
+	{
+		/// <summary>
+		/// Gets or sets the ID of the content key period. This must be unique
+		/// within the scope of this document and the value must be a valid XML
+		/// ID.
+		/// </summary>
+		public string Id { get; set; }
+
+		/// <summary>
+		/// Get or sets the numerical index for the key period. Mutually exclusive
+		/// with start and end.
+		/// </summary>
+		public int? Index { get; set; }
+
+		/// <summary>
+		/// Gets or sets the wall clock (Live) or media time (VOD) for the start time
+		/// for the period. Mutually inclusive with end, and mutually exclusive with
+		/// index.
+		/// </summary>
+		public DateTime? Start { get; set; }
+
+		/// <summary>
+		/// Gets or sets the wall clock (Live) or media time (VOD) for the end time
+		/// for the period. Mutually inclusive with start, and mutually exclusive
+		/// with index.
+		/// </summary>
+		public DateTime? End { get; set; }
+
+		internal override void ValidateNewEntity(CpixDocument document)
+		{
+			ValidateEntity();
+		}
+
+		internal override void ValidateLoadedEntity(CpixDocument document)
+		{
+			ValidateEntity();
+		}
+
+		private void ValidateEntity()
+		{
+			if ((Index == null && (Start == null || End == null))
+				|| (Index != null && (Start != null || End != null)))
+			{
+				throw new InvalidCpixDataException("For each content key period either the index or both the start and end time must be specified.");
+			}
+		}
+	}
+}

--- a/Cpix/ContentKeyPeriodCollection.cs
+++ b/Cpix/ContentKeyPeriodCollection.cs
@@ -1,0 +1,44 @@
+﻿using System.Xml;
+using Axinom.Cpix.Internal;
+
+namespace Axinom.Cpix
+{
+	sealed class ContentKeyPeriodCollection : EntityCollection<ContentKeyPeriod>
+	{
+		public const string ContainerXmlElementName = "ContentKeyPeriodList";
+
+		public ContentKeyPeriodCollection(CpixDocument document) : base(document)
+		{
+		}
+
+		internal override string ContainerName => ContainerXmlElementName;
+
+		protected override XmlElement SerializeEntity(XmlDocument document, XmlNamespaceManager namespaces, XmlElement container, ContentKeyPeriod entity)
+		{
+			var contentKeyPeriodElement = new ContentKeyPeriodElement
+			{
+				Id = entity.Id,
+				Index = entity.Index,
+				Start = entity.Start,
+				End = entity.End
+			};
+
+			return XmlHelpers.AppendChildAndReuseNamespaces(contentKeyPeriodElement, container);
+		}
+
+		protected override ContentKeyPeriod DeserializeEntity(XmlElement element, XmlNamespaceManager namespaces)
+		{
+			var contentKeyPeriodElement = XmlHelpers.Deserialize<ContentKeyPeriodElement>(element);
+
+			var contentKeyPeriod = new ContentKeyPeriod
+			{
+				Id = contentKeyPeriodElement.Id,
+				Index = contentKeyPeriodElement.Index,
+				Start = contentKeyPeriodElement.Start,
+				End = contentKeyPeriodElement.End
+			};
+
+			return contentKeyPeriod;
+		}
+	}
+}

--- a/Cpix/CpixDocument.cs
+++ b/Cpix/CpixDocument.cs
@@ -199,7 +199,7 @@ namespace Axinom.Cpix
 				{
 					// NB! Do not apply any formatting here, as digital signatures have already been generated
 					// and any formatting will invalidate the signatures!
-					Encoding = Encoding.UTF8,
+					Encoding = new UTF8Encoding(false),
 					CloseOutput = false
 				}))
 				{

--- a/Cpix/CpixDocument.cs
+++ b/Cpix/CpixDocument.cs
@@ -78,6 +78,11 @@ namespace Axinom.Cpix
 		public EntityCollection<DrmSystem> DrmSystems { get; }
 
 		/// <summary>
+		/// Gets the set of content key period entries stored in the CPIX document.
+		/// </summary>
+		public EntityCollection<ContentKeyPeriod> ContentKeyPeriods { get; }
+
+		/// <summary>
 		/// Whether the values of content keys are readable.
 		/// If false, you can only read the metadata, not the values themselves.
 		/// 
@@ -404,6 +409,7 @@ namespace Axinom.Cpix
 			Recipients = new RecipientCollection(this);
 			ContentKeys = new ContentKeyCollection(this);
 			DrmSystems = new DrmSystemCollection(this);
+			ContentKeyPeriods = new ContentKeyPeriodCollection(this);
 			UsageRules = new UsageRuleCollection(this);
 		}
 
@@ -475,6 +481,7 @@ namespace Axinom.Cpix
 			Recipients,
 			ContentKeys,
 			DrmSystems,
+			ContentKeyPeriods,
 			UsageRules
 		};
 		#endregion

--- a/Cpix/CpixDocument.cs
+++ b/Cpix/CpixDocument.cs
@@ -237,7 +237,7 @@ namespace Axinom.Cpix
 				{
 					// NB! Do not apply any formatting here, as digital signatures have already been generated
 					// and any formatting will invalidate the signatures!
-					Encoding = new UTF8Encoding(false),
+					Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier:false),
 					CloseOutput = false
 				}))
 				{

--- a/Cpix/DrmSystem.cs
+++ b/Cpix/DrmSystem.cs
@@ -37,6 +37,15 @@ namespace Axinom.Cpix
 		public string ContentProtectionData { get; set; }
 
 		/// <summary>
+		/// Gets or sets the EXT-X-KEY URI data. This is the full data to be added in
+		/// the URI attribute of the EXT-X-KEY tag of a HLS playlist. This must be UTF-8
+		/// text without a byte order mark. This shall only be set when the content is
+		/// in the HLS format. The use of this element is deprecated. Using
+		/// HLSSignalingData is recommended.
+		/// </summary>
+		public string UriExtXKey { get; set; }
+
+		/// <summary>
 		/// Gets or sets the HLS signaling data to be inserted in HLS master and/or
 		/// media playlists. The data includes #EXT-X-KEY or #EXT-X-SESSION-KEY
 		/// tags (depending on the playlist), along with potential proprietary tags.
@@ -64,6 +73,11 @@ namespace Axinom.Cpix
 		internal override void ValidateNewEntity(CpixDocument document)
 		{
 			ValidateEntity();
+
+			// Let's enforce this only for new entities, to avoid ambiguity (they
+			// contain overlapping data). But it's not against the spec.
+			if (UriExtXKey != null && HlsSignalingData != null)
+				throw new InvalidCpixDataException("A DRM system signaling entry may not contain both HLSSignalingData and URIExtXKey data, to avoid ambiguity.");
 		}
 
 		internal override void ValidateLoadedEntity(CpixDocument document)

--- a/Cpix/DrmSystemCollection.cs
+++ b/Cpix/DrmSystemCollection.cs
@@ -29,6 +29,9 @@ namespace Axinom.Cpix
 			if (entity.ContentProtectionData != null)
 				drmSystemElement.ContentProtectionData = Convert.ToBase64String(Encoding.UTF8.GetBytes(entity.ContentProtectionData));
 
+			if (entity.UriExtXKey != null)
+				drmSystemElement.UriExtXKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(entity.UriExtXKey));
+
 			if (entity.HdsSignalingData != null)
 				drmSystemElement.HdsSignalingData = Convert.ToBase64String(Encoding.UTF8.GetBytes(entity.HdsSignalingData));
 
@@ -69,6 +72,9 @@ namespace Axinom.Cpix
 
 			if (drmSystemElement.ContentProtectionData != null)
 				drmSystem.ContentProtectionData = Encoding.UTF8.GetString(Convert.FromBase64String(drmSystemElement.ContentProtectionData));
+
+			if (drmSystemElement.UriExtXKey != null)
+				drmSystem.UriExtXKey = Encoding.UTF8.GetString(Convert.FromBase64String(drmSystemElement.UriExtXKey));
 
 			if (drmSystemElement.HdsSignalingData != null)
 				drmSystem.HdsSignalingData = Encoding.UTF8.GetString(Convert.FromBase64String(drmSystemElement.HdsSignalingData));

--- a/Cpix/Internal/XmlElements.cs
+++ b/Cpix/Internal/XmlElements.cs
@@ -31,6 +31,9 @@ namespace Axinom.Cpix.Internal
 		[XmlAttribute("kid")]
 		public Guid KeyId { get; set; }
 
+		[XmlElement("KeyPeriodFilter")]
+		public KeyPeriodElement[] KeyPeriodFilters { get; set; }
+
 		[XmlElement("LabelFilter")]
 		public LabelFilterElement[] LabelFilters { get; set; }
 
@@ -51,6 +54,12 @@ namespace Axinom.Cpix.Internal
 			// Malformed rules will not work right for resolving but who are we to say what is malformed or not.
 			// Nothing to really validate here, in essence. Go wild!
 		}
+	}
+
+	public sealed class KeyPeriodElement
+	{
+		[XmlAttribute("periodId")]
+		public string PeriodId { get; set; }
 	}
 
 	public sealed class LabelFilterElement

--- a/Cpix/Internal/XmlElements.cs
+++ b/Cpix/Internal/XmlElements.cs
@@ -268,7 +268,26 @@ namespace Axinom.Cpix.Internal
 			}
 			else
 			{
-				throw new InvalidCpixDataException("Must have either ContentKey/Data/Secret/EncryptedValue or ContentKey/Data/Secret/PlainValue.");
+				// Note: This library originally considered the content key element not having any
+				// key data an error and this case threw an error ("Must have either
+				// ContentKey/Data/Secret/EncryptedValue or ContentKey/Data/Secret/PlainValue.").
+				// The 'data' element was also required at the schema level. However, according to
+				// official spec and schema content key data is optional. And in practice there's a
+				// demand for using CPIX for key request purposes where content key IDs may need to
+				// be present, but data yet really cannot be.
+				//
+				// Counter-argument from at least one of the CPIX authors (the same who created this
+				// library; see https://github.com/Dash-Industry-Forum/CPIX/issues/88) is that CPIX
+				// should only be used for key transportation and not for key requests, which would
+				// make key elements without data meaningless. Since the library likely was developed
+				// with this requirement in mind, there's some danger that the removal of this
+				// requirement may "destabilize" some flows. However, running automatic and brief
+				// manual tests revealed no problems when removing just the on-load validation.
+				//
+				// Therefore, let's not require content key data on-load, but keep the requirement
+				// when adding new content keys to avoid compromising some of the existing
+				// functionality. This is also more in line with the library's philosophy: be strict
+				// when creating a new document, but more lenient when loading existing documents.
 			}
 		}
 	}

--- a/Cpix/Internal/XmlElements.cs
+++ b/Cpix/Internal/XmlElements.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Xml;
 using System.Xml.Serialization;
@@ -248,23 +249,26 @@ namespace Axinom.Cpix.Internal
 		}
 
 		[XmlIgnore]
-		public DateTime? Start { get; set; }
+		public DateTimeOffset? Start { get; set; }
 
 		[XmlAttribute("start")]
 		public string StartAsXmlString
 		{
-			get => Start?.ToString("o"); 
-			set => Start = value != null ? (DateTime?)DateTime.Parse(value) : null;
+			// XML date-times must be in the ISO 8601 ("O") format. Also, we'll allow
+			// missing timezones in order to throw less errors. But missing ones are
+			// considered as UTC.
+			get => Start?.ToString("O"); 
+			set => Start = value != null ? (DateTimeOffset?)DateTimeOffset.Parse(value, null, DateTimeStyles.AssumeUniversal) : null;
 		}
 
 		[XmlIgnore]
-		public DateTime? End { get; set; }
+		public DateTimeOffset? End { get; set; }
 
 		[XmlAttribute("end")]
 		public string EndAsXmlString
 		{
-			get => End?.ToString("o");
-			set => End = value != null ? (DateTime?)DateTime.Parse(value) : null;
+			get => End?.ToString("O");
+			set => End = value != null ? (DateTimeOffset?)DateTimeOffset.Parse(value, null, DateTimeStyles.AssumeUniversal) : null;
 		}
 	}
 

--- a/Cpix/Internal/XmlElements.cs
+++ b/Cpix/Internal/XmlElements.cs
@@ -180,6 +180,9 @@ namespace Axinom.Cpix.Internal
 		[XmlElement]
 		public string ContentProtectionData { get; set; }
 
+		[XmlElement("URIExtXKey")]
+		public string UriExtXKey { get; set; }
+
 		[XmlElement("HLSSignalingData")]
 		public List<HlsSignalingDataElement> HlsSignalingData { get; set; } = new List<HlsSignalingDataElement>();
 

--- a/Cpix/Internal/XmlElements.cs
+++ b/Cpix/Internal/XmlElements.cs
@@ -221,6 +221,46 @@ namespace Axinom.Cpix.Internal
 	}
 	#endregion
 
+	#region Content key periods
+	[XmlRoot("ContentKeyPeriod", Namespace = Constants.CpixNamespace)]
+	public sealed class ContentKeyPeriodElement
+	{
+		[XmlAttribute("id")]
+		public string Id { get; set; }
+
+		[XmlIgnore]
+		public int? Index { get; set; }
+
+		[XmlAttribute("index")]
+		public string IndexAsXmlString
+		{
+			get => Index?.ToString();
+			set => Index = value != null ? (int?)int.Parse(value) : null;
+		}
+
+		[XmlIgnore]
+		public DateTime? Start { get; set; }
+
+		[XmlAttribute("start")]
+		public string StartAsXmlString
+		{
+			get => Start?.ToString("o"); 
+			set => Start = value != null ? (DateTime?)DateTime.Parse(value) : null;
+		}
+
+		[XmlIgnore]
+		public DateTime? End { get; set; }
+
+		[XmlAttribute("end")]
+		public string EndAsXmlString
+		{
+			get => End?.ToString("o");
+			set => End = value != null ? (DateTime?)DateTime.Parse(value) : null;
+		}
+	}
+
+	#endregion
+
 	#region Content keys
 	[XmlRoot("ContentKey", Namespace = Constants.CpixNamespace)]
 	public sealed class ContentKeyElement

--- a/Cpix/Internal/XmlElements.cs
+++ b/Cpix/Internal/XmlElements.cs
@@ -12,11 +12,16 @@ namespace Axinom.Cpix.Internal
 	// to/from the string-form of the data. XmlSerializer just converts between XML strings and string objects there.
 
 	/// <summary>
-	/// Just for creating a new blank document. The contents are serialized independently.
+	/// Just for creating a new blank document and handling root attributes. Other
+	/// serialization is performed independently.
 	/// </summary>
 	[XmlRoot("CPIX", Namespace = Constants.CpixNamespace)]
 	public sealed class DocumentRootElement
 	{
+		public const string ContentIdAttributeName = "contentId";
+
+		[XmlAttribute(ContentIdAttributeName)]
+		public string ContentId { get; set; }
 	}
 
 	#region Usage rules

--- a/Cpix/KeyPeriodFilter.cs
+++ b/Cpix/KeyPeriodFilter.cs
@@ -1,0 +1,23 @@
+﻿namespace Axinom.Cpix
+{
+	/// <summary>
+	/// A key period filter attached to a new content key assignment rule.
+	/// </summary>
+	public sealed class KeyPeriodFilter
+	{
+		/// <summary>
+		/// Gets or sets the ID of the content key period that is associated with
+		/// this filter. Null is invalid.
+		/// </summary>
+		public string PeriodId { get; set; }
+
+		/// <summary>
+		/// Validates the data in the object before it is accepted for use by this library.
+		/// </summary>
+		internal void Validate()
+		{
+			if (PeriodId == null)
+				throw new InvalidCpixDataException("A key period filter that does not reference a content key period is invalid.");
+		}
+	}
+}

--- a/Cpix/UsageRule.cs
+++ b/Cpix/UsageRule.cs
@@ -17,6 +17,7 @@ namespace Axinom.Cpix
 		/// </summary>
 		public bool ContainsUnsupportedFilters { get; internal set; }
 
+		public ICollection<KeyPeriodFilter> KeyPeriodFilters { get; set; } = new List<KeyPeriodFilter>();
 		public ICollection<VideoFilter> VideoFilters { get; set; } = new List<VideoFilter>();
 		public ICollection<AudioFilter> AudioFilters { get; set; } = new List<AudioFilter>();
 		public ICollection<LabelFilter> LabelFilters { get; set; } = new List<LabelFilter>();
@@ -35,6 +36,14 @@ namespace Axinom.Cpix
 		{
 			if (!document.ContentKeys.Any(ck => ck.Id == KeyId))
 				throw new InvalidCpixDataException("Content key usage rule references a content key that is not present in the CPIX document.");
+
+			foreach (var keyPeriodFilter in KeyPeriodFilters)
+			{
+				keyPeriodFilter.Validate();
+
+				if (!document.ContentKeyPeriods.Any(ckp => ckp.Id == keyPeriodFilter.PeriodId))
+					throw new InvalidCpixDataException("Content key usage rule key period filter references a content key period that is not present in the CPIX document.");
+			}
 
 			foreach (var videoFilter in VideoFilters)
 				videoFilter.Validate();

--- a/Cpix/UsageRule.cs
+++ b/Cpix/UsageRule.cs
@@ -27,7 +27,10 @@ namespace Axinom.Cpix
 		{
 			// This can happen if an entity with unsupported filters gets re-added to a document, for some misguided reason.
 			if (ContainsUnsupportedFilters)
-				throw new InvalidCpixDataException("Cannot add a content key usage rule that contains unsupported filters. Such usage rules can only be passed through unmodified when processing a CPIX document.");
+			{
+				throw new InvalidCpixDataException("Cannot add a content key usage rule that contains unsupported filters. " +
+					"Such usage rules can only be passed through unmodified when processing a CPIX document.");
+			}
 
 			ValidateLoadedEntity(document);
 		}
@@ -42,7 +45,10 @@ namespace Axinom.Cpix
 				keyPeriodFilter.Validate();
 
 				if (!document.ContentKeyPeriods.Any(ckp => ckp.Id == keyPeriodFilter.PeriodId))
-					throw new InvalidCpixDataException("Content key usage rule key period filter references a content key period that is not present in the CPIX document.");
+				{
+					throw new InvalidCpixDataException("Content key usage rule key period filter references a content key period " +
+						"that is not present in the CPIX document.");
+				}
 			}
 
 			foreach (var videoFilter in VideoFilters)

--- a/Cpix/UsageRuleCollection.cs
+++ b/Cpix/UsageRuleCollection.cs
@@ -68,6 +68,16 @@ namespace Axinom.Cpix
 					.ToArray();
 			}
 
+			if (entity.KeyPeriodFilters?.Count > 0)
+			{
+				element.KeyPeriodFilters = entity.KeyPeriodFilters
+					.Select(f => new KeyPeriodElement()
+					{
+						PeriodId = f.PeriodId
+					})
+					.ToArray();
+			}
+
 			return XmlHelpers.AppendChildAndReuseNamespaces(element, container);
 		}
 
@@ -133,6 +143,16 @@ namespace Axinom.Cpix
 					.ToList();
 			}
 
+			if (raw.KeyPeriodFilters?.Length > 0)
+			{
+				rule.KeyPeriodFilters = raw.KeyPeriodFilters
+					.Select(f => new KeyPeriodFilter
+					{
+						PeriodId = f.PeriodId
+					})
+					.ToList();
+			}
+			
 			return rule;
 		}
 	}

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 Axinom CPIX library
 ===================
 
-A .NET library for working with CPIX (Content Protection Information Exchange) documents, as defined by [DASH Industry Forum](http://dashif.org/guidelines/). This library implements CPIX version 2.2.
+A .NET Standard library for working with CPIX (Content Protection Information Exchange) documents, as defined by [DASH Industry Forum](http://dashif.org/guidelines/). This library implements CPIX version 2.2.
 
 Installation
 ============

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 Axinom CPIX library
 ===================
 
-A .NET library for working with CPIX (Content Protection Information Exchange) documents, as defined by [DASH Industry Forum](http://dashif.org/guidelines/). This library implements CPIX version 2.1.
+A .NET library for working with CPIX (Content Protection Information Exchange) documents, as defined by [DASH Industry Forum](http://dashif.org/guidelines/). This library implements CPIX version 2.2.
 
 Installation
 ============
@@ -33,9 +33,13 @@ The following features are implemented:
 * Delivery key identification based on X.509 certificates.
 * DRM system metadata
 
+The following features are partially implemented:
+
+* Key periods and key period filters 
+	* Read/write and basic validation. Content key resolution not implemented.
+
 The following features are NOT implemented:
 
-* Key periods and key period filters
 * Document update history
 * Minor metadata attributes (names/IDs/etc)
 * Hierarchical content keys

--- a/Resources/Schema/cpix.xsd
+++ b/Resources/Schema/cpix.xsd
@@ -17,7 +17,7 @@
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
 	</xs:complexType>
 	<xs:complexType name="KeyPeriodFilterType">
-		<xs:attribute name="periodId" type="xs:ID" use="required"/>
+		<xs:attribute name="periodId" type="xs:IDREF" use="required"/>
 	</xs:complexType>
 	<xs:complexType name="LabelFilterType">
 		<xs:attribute name="label" type="xs:string" use="required"/>

--- a/Resources/Schema/cpix.xsd
+++ b/Resources/Schema/cpix.xsd
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:cpix="urn:dashif:org:cpix" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="urn:dashif:org:cpix" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
-	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd" />
-	<xs:import namespace="urn:ietf:params:xml:ns:keyprov:pskc" schemaLocation="pskc.xsd" />
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
+	<xs:import namespace="urn:ietf:params:xml:ns:keyprov:pskc" schemaLocation="pskc.xsd"/>
 	<xs:complexType name="UpdateHistoryItemType">
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
+		<xs:attribute name="updateVersion" type="xs:integer" use="required"/>
 		<xs:attribute name="index" type="xs:string" use="required"/>
 		<xs:attribute name="source" type="xs:string" use="required"/>
 		<xs:attribute name="date" type="xs:dateTime" use="required"/>
@@ -16,7 +17,7 @@
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
 	</xs:complexType>
 	<xs:complexType name="KeyPeriodFilterType">
-		<xs:attribute name="periodId" type="xs:string" use="required"/>
+		<xs:attribute name="periodId" type="xs:ID" use="required"/>
 	</xs:complexType>
 	<xs:complexType name="LabelFilterType">
 		<xs:attribute name="label" type="xs:string" use="required"/>
@@ -48,6 +49,7 @@
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
 		<xs:attribute name="kid" type="xs:string" use="required"/>
+		<xs:attribute name="intendedTrackType" type="xs:string" use="optional"/>
 	</xs:complexType>
 	<xs:complexType name="ContentKeyUsageRuleListType">
 		<xs:sequence>
@@ -76,10 +78,10 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="PlaylistType" final="restriction" >
+	<xs:simpleType name="PlaylistType" final="restriction">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="master" />
-			<xs:enumeration value="media" />
+			<xs:enumeration value="master"/>
+			<xs:enumeration value="media"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="DRMSystemType">
@@ -93,14 +95,15 @@
 			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
+		<xs:attribute name="updateVersion" type="xs:integer" use="optional"/>
 		<xs:attribute name="systemId" type="xs:string" use="required"/>
 		<xs:attribute name="kid" type="xs:string" use="required"/>
-		<xs:attribute name="updateVersion" type="xs:integer" use="optional"/>
+		<xs:attribute name="name" type="xs:string" use="optional"/>
 	</xs:complexType>
 	<xs:complexType name="DRMSystemListType">
 		<xs:sequence>
 			<xs:element name="DRMSystem" type="cpix:DRMSystemType" minOccurs="0" maxOccurs="unbounded">
-				<xs:unique name="uniquePlaylistForEachHlsSignalingDataElement">
+				<xs:unique name="uniquePlaylistForHLSSignalingData">
 					<xs:selector xpath="cpix:HLSSignalingData"/>
 					<xs:field xpath="@playlist"/>
 				</xs:unique>
@@ -116,7 +119,7 @@
 			<xs:element name="KeyProfileId" type="xs:string" minOccurs="0"/>
 			<xs:element name="KeyReference" type="xs:string" minOccurs="0"/>
 			<xs:element name="FriendlyName" type="xs:string" minOccurs="0"/>
-			<xs:element name="Data" type="pskc:KeyDataType"/>
+			<xs:element name="Data" type="pskc:KeyDataType" minOccurs="0"/>
 			<xs:element name="UserId" type="xs:string" minOccurs="0"/>
 			<xs:element name="Policy" type="pskc:PolicyType" minOccurs="0"/>
 			<xs:element name="Extensions" type="pskc:ExtensionsType" minOccurs="0" maxOccurs="unbounded"/>
@@ -129,6 +132,7 @@
 			<xs:extension base="cpix:KeyType">
 				<xs:attribute name="kid" type="xs:string" use="required"/>
 				<xs:attribute name="explicitIV" type="xs:base64Binary" use="optional"/>
+				<xs:attribute name="dependsOnKey" type="xs:string" use="optional"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
@@ -150,8 +154,8 @@
 			<xs:element name="ReceivingEntity" type="xs:string" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
-		<xs:attribute name="name" type="xs:string" use="optional"/>
 		<xs:attribute name="updateVersion" type="xs:integer" use="optional"/>
+		<xs:attribute name="name" type="xs:string" use="optional"/>
 	</xs:complexType>
 	<xs:complexType name="DeliveryDataListType">
 		<xs:sequence>
@@ -171,6 +175,7 @@
 			<xs:element ref="ds:Signature" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
+		<xs:attribute name="contentId" type="xs:string" use="optional"/>
 		<xs:attribute name="name" type="xs:string" use="optional"/>
 	</xs:complexType>
 	<xs:element name="CPIX" type="cpix:CpixType"/>

--- a/TestVectorGenerator/Complex.cs
+++ b/TestVectorGenerator/Complex.cs
@@ -23,6 +23,8 @@ namespace Axinom.Cpix.TestVectorGenerator
 			document.ContentKeys.AddSignature(TestHelpers.Certificate4WithPrivateKey);
 			document.DrmSystems.AddSignature(TestHelpers.Certificate3WithPrivateKey);
 			document.DrmSystems.AddSignature(TestHelpers.Certificate4WithPrivateKey);
+			document.ContentKeyPeriods.AddSignature(TestHelpers.Certificate3WithPrivateKey);
+			document.ContentKeyPeriods.AddSignature(TestHelpers.Certificate4WithPrivateKey);
 			document.UsageRules.AddSignature(TestHelpers.Certificate3WithPrivateKey);
 			document.UsageRules.AddSignature(TestHelpers.Certificate4WithPrivateKey);
 
@@ -52,6 +54,18 @@ namespace Axinom.Cpix.TestVectorGenerator
 			});
 
 			DrmSignalingHelpers.AddDefaultSignalingForAllKeys(document);
+
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Id = "keyperiod_1",
+				Index = 1
+			});
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Id = "keyperiod_2",
+				Start = new DateTime(2020, 9, 4, 1, 1, 1),
+				End = new DateTime(2020, 9, 4, 2, 1, 1)
+			});
 
 			document.Recipients.Add(new Recipient(TestHelpers.Certificate1WithPublicKey));
 			document.Recipients.Add(new Recipient(TestHelpers.Certificate2WithPublicKey));

--- a/TestVectorGenerator/Complex.cs
+++ b/TestVectorGenerator/Complex.cs
@@ -63,8 +63,8 @@ namespace Axinom.Cpix.TestVectorGenerator
 			document.ContentKeyPeriods.Add(new ContentKeyPeriod
 			{
 				Id = "keyperiod_2",
-				Start = new DateTime(2020, 9, 4, 1, 1, 1),
-				End = new DateTime(2020, 9, 4, 2, 1, 1)
+				Start = new DateTimeOffset(2020, 9, 4, 1, 1, 1, TimeSpan.Zero),
+				End = new DateTimeOffset(2020, 9, 4, 2, 1, 1, TimeSpan.Zero)
 			});
 
 			document.Recipients.Add(new Recipient(TestHelpers.Certificate1WithPublicKey));

--- a/TestVectorGenerator/EvenMoreComplex.cs
+++ b/TestVectorGenerator/EvenMoreComplex.cs
@@ -78,6 +78,18 @@ The resulting output is still valid and all the signatures should successfully p
 
 			DrmSignalingHelpers.AddDefaultSignalingForAllKeys(document);
 
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Id = "keyperiod_1",
+				Index = 1
+			});
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Id = "keyperiod_2",
+				Start = new DateTime(2020, 9, 4, 1, 1, 1),
+				End = new DateTime(2020, 9, 4, 2, 1, 1)
+			});
+
 			document.Recipients.Add(new Recipient(TestHelpers.Certificate1WithPublicKey));
 			document.Recipients.Add(new Recipient(TestHelpers.Certificate2WithPublicKey));
 
@@ -187,16 +199,19 @@ The resulting output is still valid and all the signatures should successfully p
 			const string recipientsId = "id-for-recipients----";
 			const string contentKeysId = "_id_for_content_keys";
 			const string drmSystemsId = "_id_for_drm_systems";
+			const string contentKeyPeriodsId = "_id_for_content_key_periods";
 			const string usageRulesId = "a.0a.0a.0a.0a.0a.a0.0a0.0404040......";
 
 			UnusualInputTests.SetElementId(xmlDocument, namespaces, "/cpix:CPIX/cpix:DeliveryDataList", recipientsId);
 			UnusualInputTests.SetElementId(xmlDocument, namespaces, "/cpix:CPIX/cpix:ContentKeyList", contentKeysId);
 			UnusualInputTests.SetElementId(xmlDocument, namespaces, "/cpix:CPIX/cpix:DRMSystemList", drmSystemsId);
+			UnusualInputTests.SetElementId(xmlDocument, namespaces, "/cpix:CPIX/cpix:ContentKeyPeriodList", contentKeyPeriodsId);
 			UnusualInputTests.SetElementId(xmlDocument, namespaces, "/cpix:CPIX/cpix:ContentKeyUsageRuleList", usageRulesId);
 
 			CryptographyHelpers.SignXmlElement(xmlDocument, recipientsId, TestHelpers.Certificate1WithPrivateKey);
 			CryptographyHelpers.SignXmlElement(xmlDocument, contentKeysId, TestHelpers.Certificate1WithPrivateKey);
 			CryptographyHelpers.SignXmlElement(xmlDocument, drmSystemsId, TestHelpers.Certificate1WithPrivateKey);
+			CryptographyHelpers.SignXmlElement(xmlDocument, contentKeyPeriodsId, TestHelpers.Certificate1WithPrivateKey);
 			CryptographyHelpers.SignXmlElement(xmlDocument, usageRulesId, TestHelpers.Certificate1WithPrivateKey);
 			CryptographyHelpers.SignXmlElement(xmlDocument, usageRulesId, TestHelpers.Certificate2WithPrivateKey);
 			CryptographyHelpers.SignXmlElement(xmlDocument, "", TestHelpers.Certificate1WithPrivateKey);
@@ -209,11 +224,13 @@ The resulting output is still valid and all the signatures should successfully p
 			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:DeliveryDataList", namespaces));
 			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:ContentKeyList", namespaces));
 			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:DRMSystemList", namespaces));
+			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:ContentKeyPeriodList", namespaces));
 			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:ContentKeyUsageRuleList", namespaces));
 
 			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:DeliveryDataList/cpix:DeliveryData", namespaces));
 			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:ContentKeyList/cpix:ContentKey", namespaces));
 			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:DRMSystemList/cpix:DRMSystem", namespaces));
+			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:ContentKeyPeriodList/cpix:ContentKeyPeriod", namespaces));
 			UnusualInputTests.AddCommentAsChild((XmlElement)xmlDocument.SelectSingleNode("/cpix:CPIX/cpix:ContentKeyUsageRuleList/cpix:ContentKeyUsageRule", namespaces));
 
 			// Save the signed document as UTF-16.

--- a/TestVectorGenerator/EvenMoreComplex.cs
+++ b/TestVectorGenerator/EvenMoreComplex.cs
@@ -86,8 +86,8 @@ The resulting output is still valid and all the signatures should successfully p
 			document.ContentKeyPeriods.Add(new ContentKeyPeriod
 			{
 				Id = "keyperiod_2",
-				Start = new DateTime(2020, 9, 4, 1, 1, 1),
-				End = new DateTime(2020, 9, 4, 2, 1, 1)
+				Start = new DateTimeOffset(2020, 9, 4, 1, 1, 1, TimeSpan.Zero),
+				End = new DateTimeOffset(2020, 9, 4, 2, 1, 1, TimeSpan.Zero)
 			});
 
 			document.Recipients.Add(new Recipient(TestHelpers.Certificate1WithPublicKey));

--- a/Tests/ContentKeyPeriodCrudTests.cs
+++ b/Tests/ContentKeyPeriodCrudTests.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Schema;
+using Xunit;
+
+namespace Axinom.Cpix.Tests
+{
+	public sealed class ContentKeyPeriodCrudTests
+	{
+		[Fact]
+		public void AddContentKeyPeriod_WithLoadedEmptyDocument_Succeeds()
+		{
+			var document = new CpixDocument();
+			document = TestHelpers.Reload(document);
+
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Index = 1 });
+			document = TestHelpers.Reload(document);
+
+			Assert.Single(document.ContentKeyPeriods);
+		}
+
+		[Fact]
+		public void AddContentKeyPeriod_WithLoadedDocumentWithExistingContentKeyPeriod_Succeeds()
+		{
+			var document = new CpixDocument();
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Index = 1 });
+			document = TestHelpers.Reload(document);
+
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Index = 2 });
+			document = TestHelpers.Reload(document);
+
+			Assert.Equal(2, document.ContentKeyPeriods.Count);
+		}
+
+		[Fact]
+		public void AddContentKeyPeriod_WithVariousValidData_Succeeds()
+		{
+			var document = new CpixDocument();
+
+			Assert.Null(Record.Exception(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Index = 1
+			})));
+			Assert.Null(Record.Exception(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Start = DateTime.Now,
+				End = DateTime.Now
+			})));
+			Assert.Null(Record.Exception(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Id = "test",
+				Start = DateTime.Now,
+				End = DateTime.Now
+			})));
+		}
+
+		[Fact]
+		public void AddContentKeyPeriod_WithVariousInvalidData_Fails()
+		{
+			var document = new CpixDocument();
+
+			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+			}));
+			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Start = DateTime.Now
+			}));
+			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				End = DateTime.Now
+			}));
+			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Index = 1,
+				Start = DateTime.Now
+			}));
+			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Index = 1,
+				End = DateTime.Now
+			}));
+			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Index = 1,
+				Start = DateTime.Now,
+				End = DateTime.Now
+			}));
+		}
+
+		[Fact]
+		public void Save_WithSneakilyCorruptedContentKeyPeriod_Fails()
+		{
+			var contentKeyPeriod = new ContentKeyPeriod { Index = 1 };
+
+			var document = new CpixDocument();
+			// It will be validated here.
+			document.ContentKeyPeriods.Add(contentKeyPeriod);
+
+			// Corrupt it after validation!
+			contentKeyPeriod.Index = null;
+
+			// The corruption should still be caught.
+			var ex = Assert.Throws<InvalidCpixDataException>(() => document.Save(new MemoryStream()));
+			Assert.Contains("index or both the start and end time must be specified", ex.Message);
+		}
+
+		[Fact]
+		public void RemoveContentKeyPeriod_WithNewWritableCollection_Succeeds()
+		{
+			var contentKeyPeriod = new ContentKeyPeriod { Index = 1 };
+
+			var document = new CpixDocument();
+			document.ContentKeyPeriods.Add(contentKeyPeriod);
+			document.ContentKeyPeriods.Remove(contentKeyPeriod);
+
+			Assert.Empty(document.ContentKeyPeriods);
+		}
+
+		[Fact]
+		public void RemoveContentKeyPeriod_WithLoadedWritableCollection_Succeeds()
+		{
+			var contentKeyPeriod = new ContentKeyPeriod { Index = 1 };
+
+			var document = new CpixDocument();
+			document.ContentKeyPeriods.Add(contentKeyPeriod);
+			document = TestHelpers.Reload(document);
+			document.ContentKeyPeriods.Remove(document.ContentKeyPeriods.Single());
+
+			Assert.Empty(document.ContentKeyPeriods);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData("start=\"2020-09-02T18:40:49.4082171\"")]
+		[InlineData("end=\"2020-09-02T18:40:49.4082171\"")]
+		[InlineData("index=\"1\" start=\"2020-09-02T18:40:49.4082171\"")]
+		[InlineData("index=\"1\" end=\"2020-09-02T18:40:49.4082171\"")]
+		[InlineData("index=\"1\" start=\"2020-09-02T18:40:49.4082171\" end=\"2020-09-02T18:40:49.4082171\"")]
+		public void Load_WithCpixContainingContentKeyPeriodWithInvalidIndexAndStartAndEndCombination_Fails(string invalidContentKeyPeriodAttributeSet)
+		{
+			const string cpixTemplate = "<?xml version=\"1.0\" encoding=\"utf-8\"?><CPIX xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"urn:dashif:org:cpix\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:enc=\"http://www.w3.org/2001/04/xmlenc#\" xmlns:pskc=\"urn:ietf:params:xml:ns:keyprov:pskc\"><ContentKeyPeriodList><ContentKeyPeriod {0} /></ContentKeyPeriodList></CPIX>";
+
+			var cpix = string.Format(cpixTemplate, invalidContentKeyPeriodAttributeSet);
+
+			var ex = Assert.Throws<InvalidCpixDataException>(() => CpixDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(cpix))));
+			Assert.Contains("index or both the start and end time must be specified", ex.Message);
+		}
+
+		[Fact]
+		public void Save_WithCpixContainingInvalidContentKeyPeriodIdValue_FailsSchemaValidation()
+		{
+			var document = new CpixDocument();
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = "1cannotstartwithnumber", Index = 1 });
+
+			var ex = Assert.Throws<XmlSchemaValidationException>(() => document.Save(new MemoryStream()));
+			Assert.Contains("invalid according to its datatype", ex.Message);
+		}
+
+		[Fact]
+		public void Load_WithCpixContainingInvalidContentKeyPeriodIdValue_FailsSchemaValidation()
+		{
+			var ex = Assert.Throws<XmlSchemaValidationException>(() =>
+				CpixDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes("<?xml version=\"1.0\" encoding=\"utf-8\"?><CPIX xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"urn:dashif:org:cpix\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:enc=\"http://www.w3.org/2001/04/xmlenc#\" xmlns:pskc=\"urn:ietf:params:xml:ns:keyprov:pskc\"><ContentKeyPeriodList><ContentKeyPeriod id=\"1cannotstartwithnumber\" index=\"1\" /></ContentKeyPeriodList></CPIX>"))));
+
+			Assert.Contains("invalid according to its datatype", ex.Message);
+		}
+
+		[Fact]
+		public void Save_WithCpixContainingContentKeyPeriodsWithNonUniqueIds_FailsSchemaValidation()
+		{
+			var document = new CpixDocument();
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = "duplicate", Index = 1 });
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = "duplicate", Index = 2 });
+
+			var ex = Assert.Throws<XmlSchemaValidationException>(() => document.Save(new MemoryStream()));
+			Assert.Contains("is already used as an ID", ex.Message);
+		}
+
+		[Fact]
+		public void Load_WithCpixContainingContentKeyPeriodsWithNonUniqueIds_FailsSchemaValidation()
+		{
+			var ex = Assert.Throws<XmlSchemaValidationException>(() =>
+				CpixDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes("<?xml version=\"1.0\" encoding=\"utf-8\"?><CPIX xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"urn:dashif:org:cpix\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:enc=\"http://www.w3.org/2001/04/xmlenc#\" xmlns:pskc=\"urn:ietf:params:xml:ns:keyprov:pskc\"><ContentKeyPeriodList><ContentKeyPeriod id=\"id1\" index=\"1\" /><ContentKeyPeriod id=\"id1\" index=\"2\" /></ContentKeyPeriodList></CPIX>"))));
+
+			Assert.Contains("is already used as an ID", ex.Message);
+		}
+		
+		[Fact]
+		public void Roundtrip_WithSignedCollectionOfVariousValidContentKeyPeriods_Succeeds()
+		{
+			var document = new CpixDocument();
+
+			var expectedPeriod1Index = 1;
+			var expectedPeriod2Id = "period_2";
+			var expectedPeriod2Index = 2;
+			var expectedPeriod3Id = "period_3";
+			var expectedPeriod3Start = DateTime.Now;
+			var expectedPeriod3End = DateTime.Now.AddHours(1);
+
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Index = expectedPeriod1Index });
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = expectedPeriod2Id, Index = expectedPeriod2Index});
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = expectedPeriod3Id, Start = expectedPeriod3Start, End = expectedPeriod3End });
+			document.ContentKeyPeriods.AddSignature(TestHelpers.Certificate1WithPrivateKey);
+
+			document = TestHelpers.Reload(document);
+
+			Assert.Equal(3, document.ContentKeyPeriods.Count);
+
+			Assert.Null(document.ContentKeyPeriods.ElementAt(0).Id);
+			Assert.Equal(expectedPeriod1Index, document.ContentKeyPeriods.ElementAt(0).Index);
+			Assert.Null(document.ContentKeyPeriods.ElementAt(0).Start);
+			Assert.Null(document.ContentKeyPeriods.ElementAt(0).End);
+
+			Assert.Equal(expectedPeriod2Id, document.ContentKeyPeriods.ElementAt(1).Id);
+			Assert.Equal(expectedPeriod2Index, document.ContentKeyPeriods.ElementAt(1).Index);
+			Assert.Null(document.ContentKeyPeriods.ElementAt(1).Start);
+			Assert.Null(document.ContentKeyPeriods.ElementAt(1).End);
+
+			Assert.Equal(expectedPeriod3Id, document.ContentKeyPeriods.ElementAt(2).Id);
+			Assert.Null(document.ContentKeyPeriods.ElementAt(2).Index);
+			Assert.Equal(expectedPeriod3Start, document.ContentKeyPeriods.ElementAt(2).Start);
+			Assert.Equal(expectedPeriod3End, document.ContentKeyPeriods.ElementAt(2).End);
+		}
+	}
+}

--- a/Tests/RootAttributeTests.cs
+++ b/Tests/RootAttributeTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.IO;
+using System.Xml;
+using Axinom.Cpix.Internal;
+using Xunit;
+
+namespace Axinom.Cpix.Tests
+{
+	public sealed class RootAttributeTests
+	{
+		[Fact]
+		public void ContentId_ByDefault_IsNull()
+		{
+			var document = new CpixDocument();
+			Assert.Null(document.ContentId);
+		}
+
+		[Fact]
+		public void ContentId_WhenNull_IsNotSerialized()
+		{
+			var document = new CpixDocument();
+			document.ContentId = null;
+
+			var buffer = new MemoryStream();
+			document.Save(buffer);
+			buffer.Position = 0;
+
+			var xmlDocument = new XmlDocument();
+			xmlDocument.Load(buffer);
+
+			var contentIdAttribute = xmlDocument.DocumentElement.GetAttributeNode(DocumentRootElement.ContentIdAttributeName);
+
+			Assert.Null(contentIdAttribute);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		[InlineData("hello")]
+		public void ContentId_WhenSetToVariousValues_SurvivesRoundtrip(string expectedContentId)
+		{
+			var document = new CpixDocument();
+			document.ContentId = expectedContentId;
+			document = TestHelpers.Reload(document);
+
+			Assert.NotNull(document.ContentKeys);
+			Assert.Equal(expectedContentId, document.ContentId);
+		}
+
+		[Fact]
+		public void ContentId_WhenSetWhileDocumentIsReadOnly_ThrowsInvalidOperationException()
+		{
+			var document = new CpixDocument();
+			document.SignedBy = TestHelpers.Certificate1WithPrivateKey;
+			document = TestHelpers.Reload(document);
+
+			Assert.Throws<InvalidOperationException>(() => document.ContentId = "fail");
+		}
+	}
+}

--- a/Tests/SigningInteractionTests.cs
+++ b/Tests/SigningInteractionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Xunit;
 
 namespace Axinom.Cpix.Tests
@@ -10,21 +11,41 @@ namespace Axinom.Cpix.Tests
 	{
 		private Func<CpixDocument, EntityCollectionBase> RecipientsSelector = doc => doc.Recipients;
 		private Func<CpixDocument, EntityCollectionBase> ContentKeysSelector = doc => doc.ContentKeys;
+		private Func<CpixDocument, EntityCollectionBase> DrmSystemsSelector = doc => doc.DrmSystems;
+		private Func<CpixDocument, EntityCollectionBase> ContentKeyPeriodsSelector = doc => doc.ContentKeyPeriods;
 		private Func<CpixDocument, EntityCollectionBase> UsageRulesSelector = doc => doc.UsageRules;
 
 		private Action<CpixDocument> AddRecipient = doc => doc.Recipients.Add(new Recipient(TestHelpers.Certificate3WithPublicKey));
 		private Action<CpixDocument> AddContentKey = doc => doc.ContentKeys.Add(TestHelpers.GenerateContentKey());
+		private Action<CpixDocument> AddDrmSystem = doc =>
+		{
+			doc.ContentKeys.Add(TestHelpers.GenerateContentKey());
+			doc.DrmSystems.Add(new DrmSystem
+			{
+				SystemId = DrmSignalingHelpers.PlayReadySystemId,
+				KeyId = doc.ContentKeys.First().Id,
+				ContentProtectionData = DrmSignalingHelpers.GeneratePlayReadyDashSignaling(doc.ContentKeys.First().Id),
+
+			});
+		};
+		private Action<CpixDocument> AddContentKeyPeriod = doc =>
+		{
+			doc.ContentKeyPeriods.Add(new ContentKeyPeriod { Index = 1 });
+		};
 		private Action<CpixDocument> AddUsageRule = doc =>
 		{
 			doc.ContentKeys.Add(TestHelpers.GenerateContentKey());
 			TestHelpers.AddUsageRule(doc);
 		};
 
+
 		[Fact]
 		public void Clear_WithRemovedCollectionSignature_Succeeds()
 		{
 			Execute_Clear_WithRemovedCollectionSignature(RecipientsSelector, AddRecipient);
 			Execute_Clear_WithRemovedCollectionSignature(ContentKeysSelector, AddContentKey);
+			Execute_Clear_WithRemovedCollectionSignature(DrmSystemsSelector, AddDrmSystem);
+			Execute_Clear_WithRemovedCollectionSignature(ContentKeyPeriodsSelector, AddContentKeyPeriod);
 			Execute_Clear_WithRemovedCollectionSignature(UsageRulesSelector, AddUsageRule);
 		}
 
@@ -33,6 +54,8 @@ namespace Axinom.Cpix.Tests
 		{
 			Execute_Clear_WithReappliedCollectionSignature(RecipientsSelector, AddRecipient);
 			Execute_Clear_WithReappliedCollectionSignature(ContentKeysSelector, AddContentKey);
+			Execute_Clear_WithReappliedCollectionSignature(DrmSystemsSelector, AddDrmSystem);
+			Execute_Clear_WithReappliedCollectionSignature(ContentKeyPeriodsSelector, AddContentKeyPeriod);
 			Execute_Clear_WithReappliedCollectionSignature(UsageRulesSelector, AddUsageRule);
 		}
 
@@ -41,6 +64,8 @@ namespace Axinom.Cpix.Tests
 		{
 			Execute_Clear_WithRemovedDocumentSignature(RecipientsSelector, AddRecipient);
 			Execute_Clear_WithRemovedDocumentSignature(ContentKeysSelector, AddContentKey);
+			Execute_Clear_WithRemovedDocumentSignature(DrmSystemsSelector, AddDrmSystem);
+			Execute_Clear_WithRemovedDocumentSignature(ContentKeyPeriodsSelector, AddContentKeyPeriod);
 			Execute_Clear_WithRemovedDocumentSignature(UsageRulesSelector, AddUsageRule);
 		}
 
@@ -49,6 +74,8 @@ namespace Axinom.Cpix.Tests
 		{
 			Execute_Clear_WithReappliedDocumentSignature(RecipientsSelector, AddRecipient);
 			Execute_Clear_WithReappliedDocumentSignature(ContentKeysSelector, AddContentKey);
+			Execute_Clear_WithReappliedDocumentSignature(DrmSystemsSelector, AddDrmSystem);
+			Execute_Clear_WithReappliedDocumentSignature(ContentKeyPeriodsSelector, AddContentKeyPeriod);
 			Execute_Clear_WithReappliedDocumentSignature(UsageRulesSelector, AddUsageRule);
 		}
 
@@ -57,6 +84,8 @@ namespace Axinom.Cpix.Tests
 		{
 			Execute_Clear_WithReappliedDocumentAndCollectionSignature(RecipientsSelector, AddRecipient);
 			Execute_Clear_WithReappliedDocumentAndCollectionSignature(ContentKeysSelector, AddContentKey);
+			Execute_Clear_WithReappliedDocumentAndCollectionSignature(DrmSystemsSelector, AddDrmSystem);
+			Execute_Clear_WithReappliedDocumentAndCollectionSignature(ContentKeyPeriodsSelector, AddContentKeyPeriod);
 			Execute_Clear_WithReappliedDocumentAndCollectionSignature(UsageRulesSelector, AddUsageRule);
 		}
 
@@ -65,6 +94,8 @@ namespace Axinom.Cpix.Tests
 		{
 			Execute_Clear_WithExistingCollectionSignature(RecipientsSelector, AddRecipient);
 			Execute_Clear_WithExistingCollectionSignature(ContentKeysSelector, AddContentKey);
+			Execute_Clear_WithExistingCollectionSignature(DrmSystemsSelector, AddDrmSystem);
+			Execute_Clear_WithExistingCollectionSignature(ContentKeyPeriodsSelector, AddContentKeyPeriod);
 			Execute_Clear_WithExistingCollectionSignature(UsageRulesSelector, AddUsageRule);
 		}
 
@@ -73,6 +104,8 @@ namespace Axinom.Cpix.Tests
 		{
 			Execute_Clear_WithExistingDocumentSignature(RecipientsSelector, AddRecipient);
 			Execute_Clear_WithExistingDocumentSignature(ContentKeysSelector, AddContentKey);
+			Execute_Clear_WithExistingDocumentSignature(DrmSystemsSelector, AddDrmSystem);
+			Execute_Clear_WithExistingDocumentSignature(ContentKeyPeriodsSelector, AddContentKeyPeriod);
 			Execute_Clear_WithExistingDocumentSignature(UsageRulesSelector, AddUsageRule);
 		}
 
@@ -81,6 +114,8 @@ namespace Axinom.Cpix.Tests
 		{
 			Execute_Clear_WithExistingDocumentAndCollectionSignature(RecipientsSelector, AddRecipient);
 			Execute_Clear_WithExistingDocumentAndCollectionSignature(ContentKeysSelector, AddContentKey);
+			Execute_Clear_WithExistingDocumentAndCollectionSignature(DrmSystemsSelector, AddDrmSystem);
+			Execute_Clear_WithExistingDocumentAndCollectionSignature(ContentKeyPeriodsSelector, AddContentKeyPeriod);
 			Execute_Clear_WithExistingDocumentAndCollectionSignature(UsageRulesSelector, AddUsageRule);
 		}
 

--- a/Tests/SigningInteractionTests.cs
+++ b/Tests/SigningInteractionTests.cs
@@ -35,6 +35,7 @@ namespace Axinom.Cpix.Tests
 		private Action<CpixDocument> AddUsageRule = doc =>
 		{
 			doc.ContentKeys.Add(TestHelpers.GenerateContentKey());
+			doc.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = "keyperiod_" + Guid.NewGuid(), Index = 1 });
 			TestHelpers.AddUsageRule(doc);
 		};
 

--- a/Tests/SigningTests.cs
+++ b/Tests/SigningTests.cs
@@ -121,6 +121,7 @@ namespace Axinom.Cpix.Tests
 		{
 			var document = new CpixDocument();
 			TestHelpers.PopulateCollections(document);
+			document.ContentId = "test";
 
 			document.SignedBy = TestHelpers.Certificate1WithPrivateKey;
 
@@ -148,6 +149,7 @@ namespace Axinom.Cpix.Tests
 		{
 			var document = new CpixDocument();
 			TestHelpers.PopulateCollections(document);
+			document.ContentId = "test";
 
 			document = TestHelpers.Reload(document);
 
@@ -177,6 +179,7 @@ namespace Axinom.Cpix.Tests
 		{
 			var document = new CpixDocument();
 			TestHelpers.PopulateCollections(document);
+			document.ContentId = "test";
 
 			document.SignedBy = TestHelpers.Certificate1WithPrivateKey;
 
@@ -207,6 +210,7 @@ namespace Axinom.Cpix.Tests
 		{
 			var document = new CpixDocument();
 			TestHelpers.PopulateCollections(document);
+			document.ContentId = "test";
 
 			document.SignedBy = TestHelpers.Certificate1WithPrivateKey;
 

--- a/Tests/SigningTests.cs
+++ b/Tests/SigningTests.cs
@@ -259,6 +259,7 @@ namespace Axinom.Cpix.Tests
 		{
 			var document = new CpixDocument();
 			document.ContentKeys.Add(TestHelpers.GenerateContentKey());
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = "period_1", Index = 1});
 			TestHelpers.AddUsageRule(document);
 
 			Assert.ThrowsAny<ArgumentException>(() => document.ContentKeys.AddSignature(TestHelpers.Certificate1WithPublicKey));
@@ -271,6 +272,7 @@ namespace Axinom.Cpix.Tests
 		{
 			var document = new CpixDocument();
 			document.ContentKeys.Add(TestHelpers.GenerateContentKey());
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = "period_1", Index = 1 });
 			TestHelpers.AddUsageRule(document);
 			document.SignedBy = TestHelpers.Certificate1WithPrivateKey;
 

--- a/Tests/SmokeTests.cs
+++ b/Tests/SmokeTests.cs
@@ -79,6 +79,25 @@ namespace Axinom.Cpix.Tests
 		}
 
 		[Fact]
+		public void Save_DoesNotAddBomToStream()
+		{
+			var expectedFirstFiveBytes = new [] { (byte)'<', (byte)'?', (byte)'x', (byte)'m', (byte)'l' } ;
+
+			var document = new CpixDocument();
+
+			using (var buffer = new MemoryStream())
+			{
+				document.Save(buffer);
+				
+				buffer.Position = 0;
+				var firstFiveBytes = new byte[5];
+				buffer.Read(firstFiveBytes, 0, 5);
+
+				Assert.Equal(expectedFirstFiveBytes, firstFiveBytes);
+			}
+		}
+
+		[Fact]
 		public void RoundTrip_WithOneClearKey_LoadsExpectedKey()
 		{
 			var keyData = TestHelpers.GenerateKeyData();

--- a/Tests/SmokeTests.cs
+++ b/Tests/SmokeTests.cs
@@ -17,6 +17,7 @@ namespace Axinom.Cpix.Tests
 			Assert.Empty(document.Recipients);
 			Assert.Empty(document.ContentKeys);
 			Assert.Empty(document.UsageRules);
+			Assert.Null(document.ContentId);
 		}
 
 		[Fact]
@@ -32,6 +33,7 @@ namespace Axinom.Cpix.Tests
 			Assert.Empty(document.Recipients);
 			Assert.Empty(document.ContentKeys);
 			Assert.Empty(document.UsageRules);
+			Assert.Null(document.ContentId);
 		}
 
 		[Fact]

--- a/Tests/TestHelpers.cs
+++ b/Tests/TestHelpers.cs
@@ -130,8 +130,8 @@ namespace Axinom.Cpix.Tests
 			document.ContentKeyPeriods.Add(new ContentKeyPeriod
 			{
 				Id = "keyperiod_1",
-				Start = DateTime.Now,
-				End = DateTime.Now.AddHours(1)
+				Start = DateTimeOffset.UtcNow,
+				End = DateTimeOffset.UtcNow.AddHours(1)
 			});
 
 			AddUsageRule(document);

--- a/Tests/TestHelpers.cs
+++ b/Tests/TestHelpers.cs
@@ -122,6 +122,13 @@ namespace Axinom.Cpix.Tests
 				ContentProtectionData = "<pssh>Imaginary content protection data XML</pssh>"
 			});
 
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod
+			{
+				Id = "keyperiod_1",
+				Start = DateTime.Now,
+				End = DateTime.Now.AddHours(1)
+			});
+
 			// Sanity check.
 			foreach (var collection in document.EntityCollections)
 				if (collection.Count == 0)

--- a/Tests/TestHelpers.cs
+++ b/Tests/TestHelpers.cs
@@ -41,6 +41,7 @@ namespace Axinom.Cpix.Tests
 		public static UsageRule AddUsageRule(CpixDocument document)
 		{
 			var contentKey = document.ContentKeys.First();
+			var contentKeyPeriod = document.ContentKeyPeriods.First();
 
 			var rule = new UsageRule
 			{
@@ -93,6 +94,13 @@ namespace Axinom.Cpix.Tests
 						WideColorGamut = false,
 						HighDynamicRange = false,
 					}
+				},
+				KeyPeriodFilters = new[]
+				{
+					new KeyPeriodFilter
+					{
+						PeriodId = contentKeyPeriod.Id
+					}
 				}
 			};
 
@@ -112,9 +120,6 @@ namespace Axinom.Cpix.Tests
 			document.ContentKeys.Add(key1);
 			document.ContentKeys.Add(key2);
 
-			AddUsageRule(document);
-			AddUsageRule(document);
-
 			document.DrmSystems.Add(new DrmSystem
 			{
 				SystemId = Guid.NewGuid(),
@@ -128,6 +133,9 @@ namespace Axinom.Cpix.Tests
 				Start = DateTime.Now,
 				End = DateTime.Now.AddHours(1)
 			});
+
+			AddUsageRule(document);
+			AddUsageRule(document);
 
 			// Sanity check.
 			foreach (var collection in document.EntityCollections)

--- a/Tests/UnusualInputTests.cs
+++ b/Tests/UnusualInputTests.cs
@@ -271,6 +271,7 @@ namespace Axinom.Cpix.Tests
 		{
 			document.ContentKeys.Add(TestHelpers.GenerateContentKey());
 			document.ContentKeys.Add(TestHelpers.GenerateContentKey());
+			document.ContentKeyPeriods.Add(new ContentKeyPeriod { Id = "keyperiod_1", Index = 1 });
 			document.Recipients.Add(new Recipient(TestHelpers.Certificate3WithPublicKey));
 			document.Recipients.Add(new Recipient(TestHelpers.Certificate4WithPublicKey));
 			TestHelpers.AddUsageRule(document);


### PR DESCRIPTION
Summary of changes:

- Synchronized schema with official CPIX 2.2. XSD + key period filter IDREF bugfix from CPIX 2.3 schema.
- Made content key data optional in loaded documents (to align with CPIX spec). Still required on save.
- Added root ContentID attribute support.
- Added content key period support (only basic validation).
- Added partial key period filter support (read/write; but no content key resolution or advanced constraint checking)
- Added URIExtXKey support (this is deprecated, but has popular demand).
- Documents are now saved without BOM.
- Readme update.