### PR TITLE
Add 256-bit key support

### DIFF
--- a/Cpix/Constants.cs
+++ b/Cpix/Constants.cs
@@ -22,7 +22,9 @@ namespace Axinom.Cpix
 
 		public const string Sha512Algorithm = "http://www.w3.org/2001/04/xmlenc#sha512";
 
-		public const int ContentKeyLengthInBytes = 16;
+		public static readonly int[] ValidContentKeyLengthsInBytes = new[] { 16, 32 };
+		public static string ValidContentKeyLengthsHumanReadable => string.Join(", ", ValidContentKeyLengthsInBytes);
+
 		public const int ContentKeyExplicitIvLengthInBytes = 16;
 
 		/// <summary>

--- a/Cpix/ContentKey.cs
+++ b/Cpix/ContentKey.cs
@@ -44,16 +44,15 @@ namespace Axinom.Cpix
 			ValidateEntity(document);
 
 			// We skip length check if we do not have a value for an encrypted key (it will be read-only).
-			if (IsLoadedEncryptedKey && Value != null && !Constants.ValidContentKeyLengthsInBytes.Contains(Value.Length))
-				throw new InvalidCpixDataException($"Loaded content key must have a key value key with size from the set: {Constants.ValidContentKeyLengthsHumanReadable}.");
+			if (IsLoadedEncryptedKey && Value != null)
+				ValidateContentKeyValueAndSize(document);
 		}
 
 		internal override void ValidateNewEntity(CpixDocument document)
 		{
 			ValidateEntity(document);
 
-			if (Value == null || !Constants.ValidContentKeyLengthsInBytes.Contains(Value.Length))
-				throw new InvalidCpixDataException($"Created content key must have a key value key with size from the set: {Constants.ValidContentKeyLengthsHumanReadable}.");
+			ValidateContentKeyValueAndSize(document);
 		}
 
 		private void ValidateEntity(CpixDocument document)
@@ -70,6 +69,12 @@ namespace Axinom.Cpix
 					$"The Common Encryption protection scheme associated with content keys must be one of" +
 					$"{string.Join(", ", Constants.ValidCommonEncryptionSchemes.Select(x => $"'{x}'"))}.");
 			}
+		}
+
+		private void ValidateContentKeyValueAndSize(CpixDocument document)
+		{
+			if (Value == null || !Constants.ValidContentKeyLengthsInBytes.Contains(Value.Length))
+				throw new InvalidCpixDataException($"A content key must have a key value with a byte-size from the set: {Constants.ValidContentKeyLengthsHumanReadable}.");
 		}
 	}
 }

--- a/Cpix/ContentKey.cs
+++ b/Cpix/ContentKey.cs
@@ -44,16 +44,16 @@ namespace Axinom.Cpix
 			ValidateEntity(document);
 
 			// We skip length check if we do not have a value for an encrypted key (it will be read-only).
-			if (IsLoadedEncryptedKey && Value != null && Value.Length != Constants.ContentKeyLengthInBytes)
-				throw new InvalidCpixDataException($"A {Constants.ContentKeyLengthInBytes}-byte value must be provided for each new content key.");
+			if (IsLoadedEncryptedKey && Value != null && !Constants.ValidContentKeyLengthsInBytes.Contains(Value.Length))
+				throw new InvalidCpixDataException($"Loaded content key must have a key value key with size from the set: {Constants.ValidContentKeyLengthsHumanReadable}.");
 		}
 
 		internal override void ValidateNewEntity(CpixDocument document)
 		{
 			ValidateEntity(document);
 
-			if (Value == null || Value.Length != Constants.ContentKeyLengthInBytes)
-				throw new InvalidCpixDataException($"A {Constants.ContentKeyLengthInBytes}-byte value must be provided for each new content key.");
+			if (Value == null || !Constants.ValidContentKeyLengthsInBytes.Contains(Value.Length))
+				throw new InvalidCpixDataException($"Created content key must have a key value key with size from the set: {Constants.ValidContentKeyLengthsHumanReadable}.");
 		}
 
 		private void ValidateEntity(CpixDocument document)

--- a/Cpix/Internal/XmlElements.cs
+++ b/Cpix/Internal/XmlElements.cs
@@ -317,22 +317,23 @@ namespace Axinom.Cpix.Internal
 				if (Data.Secret.EncryptedValue.CipherData?.CipherValue == null || Data.Secret.EncryptedValue.CipherData?.CipherValue.Length == 0)
 					throw new InvalidCpixDataException("ContentKey/Data/Secret/EncryptedValue/CipherData/CipherValue element is missing.");
 
-				// 128-bit IV + 128-bit encrypted content key + 128-bit PKCS#7 padding block.
-				var expectedLength = (128 + 128 + 128) / 8;
+				// 128-bit IV + N-bit encrypted content key + 128-bit PKCS#7 padding block.
+				var validLengths = Constants.ValidContentKeyLengthsInBytes
+					.Select(contentKeyLength => contentKeyLength + (128 + 128) / 8)
+					.ToList();
 
-				if (Data.Secret.EncryptedValue.CipherData?.CipherValue.Length != expectedLength)
-					throw new InvalidCpixDataException("ContentKey/Data/Secret/EncryptedValue/CipherData/CipherValue element does not contain the expected number of bytes (" + expectedLength + ")");
+				if (!validLengths.Contains(Data.Secret.EncryptedValue.CipherData?.CipherValue.Length ?? 0))
+					throw new InvalidCpixDataException("ContentKey/Data/Secret/EncryptedValue/CipherData/CipherValue element does not contain the expected number of bytes (any of " + string.Join(", ", validLengths) + ")");
 
 				if (Data?.Secret?.ValueMAC == null)
 					throw new NotSupportedException("Expected ContentKey/Data/Secret/ValueMAC element does not exist.");
 			}
 			else if (HasPlainValue)
 			{
-				// 128-bit content key.
-				var expectedLength = 128 / 8;
+				var validLengths = Constants.ValidContentKeyLengthsInBytes;
 
-				if (Data.Secret.PlainValue.Length != expectedLength)
-					throw new InvalidCpixDataException("ContentKey/Data/Secret/PlainValue element does not contain the expected number of bytes (" + expectedLength + ")");
+				if (!validLengths.Contains(Data.Secret.PlainValue.Length))
+					throw new InvalidCpixDataException("ContentKey/Data/Secret/PlainValue element does not contain the expected number of bytes (any of " + Constants.ValidContentKeyLengthsHumanReadable + ")");
 			}
 			else
 			{

--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,7 @@ Features
 The following features are implemented:
 
 * Content key save/load
+	* Supports 128-bit and 256-bit keys
 * Usage rule save/load
 * Resolving content keys based on usage rules
 * Encryption of content keys (optional)
@@ -35,7 +36,7 @@ The following features are implemented:
 
 The following features are partially implemented:
 
-* Key periods and key period filters 
+* Key periods and key period filters
 	* Read/write and basic validation. Content key resolution not implemented.
 
 The following features are NOT implemented:

--- a/Tests/ContentKeyCrudTests.cs
+++ b/Tests/ContentKeyCrudTests.cs
@@ -40,42 +40,47 @@ namespace Axinom.Cpix.Tests
 			Assert.Null(Record.Exception(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 			})));
 			Assert.Null(Record.Exception(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.Last()],
+			})));
+			Assert.Null(Record.Exception(() => document.ContentKeys.Add(new ContentKey
+			{
+				Id = Guid.NewGuid(),
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				ExplicitIv = new byte[Constants.ContentKeyExplicitIvLengthInBytes]
 			})));
 			Assert.Null(Record.Exception(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				ExplicitIv = null
 			})));
 			Assert.Null(Record.Exception(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				CommonEncryptionScheme = "cenc"
 			})));
 			Assert.Null(Record.Exception(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				CommonEncryptionScheme = "cens"
 			})));
 			Assert.Null(Record.Exception(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				CommonEncryptionScheme = "cbc1"
 			})));
 			Assert.Null(Record.Exception(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				CommonEncryptionScheme = "cbcs"
 			})));
 		}
@@ -113,25 +118,25 @@ namespace Axinom.Cpix.Tests
 			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				ExplicitIv = new byte[Constants.ContentKeyExplicitIvLengthInBytes + 1]
 			}));
 			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				ExplicitIv = new byte[0]
 			}));
 			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				CommonEncryptionScheme = ""
 			}));
 			Assert.Throws<InvalidCpixDataException>(() => document.ContentKeys.Add(new ContentKey
 			{
 				Id = Guid.NewGuid(),
-				Value = new byte[Constants.ContentKeyLengthInBytes],
+				Value = new byte[Constants.ValidContentKeyLengthsInBytes.First()],
 				CommonEncryptionScheme = "abcd"
 			}));
 		}


### PR DESCRIPTION
The library will now consider keys valid if they are either 128-bit or 256-bit in size. This allows the library to be used in scenarios where 256 bit keys are used.

The CPIX specification does not place restrictions on key size, so the 128-bit limit was was only a library-specific limitation.