### PR TITLE
Allowed ContentKeys with null value.

### DIFF
--- a/Cpix/ContentKey.cs
+++ b/Cpix/ContentKey.cs
@@ -73,7 +73,7 @@ namespace Axinom.Cpix
 
 		private void ValidateContentKeyValueAndSize(CpixDocument document)
 		{
-			if (Value == null || !Constants.ValidContentKeyLengthsInBytes.Contains(Value.Length))
+			if (Value != null && !Constants.ValidContentKeyLengthsInBytes.Contains(Value.Length))
 				throw new InvalidCpixDataException($"A content key must have a key value with a byte-size from the set: {Constants.ValidContentKeyLengthsHumanReadable}.");
 		}
 	}

--- a/Cpix/ContentKey.cs
+++ b/Cpix/ContentKey.cs
@@ -73,6 +73,9 @@ namespace Axinom.Cpix
 
 		private void ValidateContentKeyValueAndSize(CpixDocument document)
 		{
+			// We support content keys without a value because many packagers
+			// create such documents for requesting keys from key services,
+			// which then fill in the value.
 			if (Value != null && !Constants.ValidContentKeyLengthsInBytes.Contains(Value.Length))
 				throw new InvalidCpixDataException($"A content key must have a key value with a byte-size from the set: {Constants.ValidContentKeyLengthsHumanReadable}.");
 		}

--- a/Cpix/ContentKeyCollection.cs
+++ b/Cpix/ContentKeyCollection.cs
@@ -24,63 +24,68 @@ namespace Axinom.Cpix
 				KeyId = entity.Id,
 				ExplicitIv = entity.ExplicitIv,
 				CommonEncryptionScheme = entity.CommonEncryptionScheme,
-				Data = new DataElement
-				{
-					Secret = new SecretDataElement()
-				}
 			};
 
-			if (Document.Recipients.Any())
+			if (entity.Value != null)
 			{
-				// We have to encrypt the key. Okay. Ensure we have the crypto values available.
-				if (Document.DocumentKey == null)
-					Document.GenerateKeys();
-
-				// Unique IV is generated for every content key.
-				var iv = new byte[128 / 8];
-
-				using (var random = RandomNumberGenerator.Create())
-					random.GetBytes(iv);
-
-				var aes = new AesManaged
+				element.Data = new DataElement
 				{
-					BlockSize = 128,
-					KeySize = 256,
-					Key = Document.DocumentKey,
-					Mode = CipherMode.CBC,
-					Padding = PaddingMode.PKCS7,
-					IV = iv
+					Secret = new SecretDataElement()
 				};
 
-				var mac = new HMACSHA512(Document.MacKey);
-
-				using (var encryptor = aes.CreateEncryptor())
+				if (Document.Recipients.Any())
 				{
-					var encryptedValue = encryptor.TransformFinalBlock(entity.Value, 0, entity.Value.Length);
+					// We have to encrypt the key. Okay. Ensure we have the crypto values available.
+					if (Document.DocumentKey == null)
+						Document.GenerateKeys();
 
-					// NB! We prepend the IV to the value when saving an encrypted value to the document field.
-					var fieldValue = iv.Concat(encryptedValue).ToArray();
+					// Unique IV is generated for every content key.
+					var iv = new byte[128 / 8];
 
-					element.Data.Secret.EncryptedValue = new EncryptedXmlValue
+					using (var random = RandomNumberGenerator.Create())
+						random.GetBytes(iv);
+
+					var aes = new AesManaged
 					{
-						CipherData = new CipherDataContainer
-						{
-							CipherValue = fieldValue
-						},
-						EncryptionMethod = new EncryptionMethodDeclaration
-						{
-							Algorithm = Constants.Aes256CbcAlgorithm
-						}
+						BlockSize = 128,
+						KeySize = 256,
+						Key = Document.DocumentKey,
+						Mode = CipherMode.CBC,
+						Padding = PaddingMode.PKCS7,
+						IV = iv
 					};
 
-					// Never not MAC.
-					element.Data.Secret.ValueMAC = mac.ComputeHash(fieldValue);
+					var mac = new HMACSHA512(Document.MacKey);
+
+
+					using (var encryptor = aes.CreateEncryptor())
+					{
+						var encryptedValue = encryptor.TransformFinalBlock(entity.Value, 0, entity.Value.Length);
+
+						// NB! We prepend the IV to the value when saving an encrypted value to the document field.
+						var fieldValue = iv.Concat(encryptedValue).ToArray();
+
+						element.Data.Secret.EncryptedValue = new EncryptedXmlValue
+						{
+							CipherData = new CipherDataContainer
+							{
+								CipherValue = fieldValue
+							},
+							EncryptionMethod = new EncryptionMethodDeclaration
+							{
+								Algorithm = Constants.Aes256CbcAlgorithm
+							}
+						};
+
+						// Never not MAC.
+						element.Data.Secret.ValueMAC = mac.ComputeHash(fieldValue);
+					}
 				}
-			}
-			else
-			{
-				// We are saving the key in the clear.
-				element.Data.Secret.PlainValue = entity.Value;
+				else
+				{
+					// We are saving the key in the clear.
+					element.Data.Secret.PlainValue = entity.Value;
+				}
 			}
 
 			return XmlHelpers.AppendChildAndReuseNamespaces(element, container);

--- a/Cpix/ContentKeyCollection.cs
+++ b/Cpix/ContentKeyCollection.cs
@@ -26,6 +26,9 @@ namespace Axinom.Cpix
 				CommonEncryptionScheme = entity.CommonEncryptionScheme,
 			};
 
+			// We support content keys without a value because many packagers
+			// create such documents for requesting keys from key services,
+			// which then fill in the value.
 			if (entity.Value != null)
 			{
 				element.Data = new DataElement
@@ -56,7 +59,6 @@ namespace Axinom.Cpix
 					};
 
 					var mac = new HMACSHA512(Document.MacKey);
-
 
 					using (var encryptor = aes.CreateEncryptor())
 					{

--- a/Tests/ContentKeyCrudTests.cs
+++ b/Tests/ContentKeyCrudTests.cs
@@ -167,7 +167,7 @@ namespace Axinom.Cpix.Tests
 		}
 
 		[Fact]
-		public void Save_WithInvalidContentKey_Fails()
+		public void Save_WithSneakilyCorruptedContentKey_Fails()
 		{
 			var contentKey = TestHelpers.GenerateContentKey();
 
@@ -175,10 +175,10 @@ namespace Axinom.Cpix.Tests
 			// It will be validated here.
 			document.ContentKeys.Add(contentKey);
 
-			// Invalidate it after validation!
-			contentKey.Id = Guid.Empty;
+			// Corrupt it after validation!
+			contentKey.Value = new byte[5];
 
-			// The invalidation should still be caught.
+			// The corruption should still be caught.
 			Assert.Throws<InvalidCpixDataException>(() => document.Save(new MemoryStream()));
 		}
 


### PR DESCRIPTION
Loading CPIX documents without content keys have always been possible, but not creating new ones. However, creating such documents is desirable for testing purposes -- many encoders/packagers create "CPIX requests" that do not have content keys. 