### PR TITLE
Allow UriExtXKey together with HlsSignalingData when creating new elements

### DIFF
--- a/Cpix/DrmSystem.cs
+++ b/Cpix/DrmSystem.cs
@@ -73,11 +73,6 @@ namespace Axinom.Cpix
 		internal override void ValidateNewEntity(CpixDocument document)
 		{
 			ValidateEntity();
-
-			// Let's enforce this only for new entities, to avoid ambiguity (they
-			// contain overlapping data). But it's not against the spec.
-			if (UriExtXKey != null && HlsSignalingData != null)
-				throw new InvalidCpixDataException("A DRM system signaling entry may not contain both HLSSignalingData and URIExtXKey data, to avoid ambiguity.");
 		}
 
 		internal override void ValidateLoadedEntity(CpixDocument document)

--- a/Tests/DrmSystemCrudTests.cs
+++ b/Tests/DrmSystemCrudTests.cs
@@ -77,6 +77,24 @@ namespace Axinom.Cpix.Tests
 				HdsSignalingData = "<aa:drmAdditionalHeader xmlns:aa=\"urn:test\">data</aa:drmAdditionalHeader>"
 			})));
 		}
+		
+		[Fact]
+		public void AddDrmSystem_WithBothHlsSignalingDataAndUriExtXKey_Succeeds()
+		{
+			var document = new CpixDocument();
+
+			Assert.Null(Record.Exception(() => document.DrmSystems.Add(new DrmSystem
+			{
+				SystemId = Guid.NewGuid(),
+				KeyId = Guid.NewGuid(),
+				UriExtXKey = "anything is valid",
+				HlsSignalingData = new HlsSignalingData()
+				{
+					MasterPlaylistData = "master",
+					MediaPlaylistData = "media"
+				}
+			})));
+		}
 
 		[Fact]
 		public void AddDrmSystem_WithVariousInvalidData_Fails()
@@ -104,13 +122,6 @@ namespace Axinom.Cpix.Tests
 				SystemId = Guid.NewGuid(),
 				KeyId = Guid.NewGuid(),
 				ContentProtectionData = "<undeclaredprefix:test></undeclaredprefix:test>"
-			}));
-			Assert.Throws<InvalidCpixDataException>(() => document.DrmSystems.Add(new DrmSystem
-			{
-				SystemId = Guid.NewGuid(),
-				KeyId = Guid.NewGuid(),
-				UriExtXKey = "mutually exclusive with HLSSignalingData when adding new data",
-				HlsSignalingData = new HlsSignalingData()
 			}));
 			Assert.Throws<InvalidCpixDataException>(() => document.DrmSystems.Add(new DrmSystem
 			{


### PR DESCRIPTION
Some packagers handle both UriExtXKey and HlsSignalingData at the same time, even though only one should be enough. Let's remove this restriction to deal with them more easily.